### PR TITLE
Fix musl build

### DIFF
--- a/src/subprocs.c
+++ b/src/subprocs.c
@@ -36,6 +36,7 @@
 # define fork  vfork
 #endif /* VMS */
 
+#define _POSIX_SOURCE
 #include <signal.h>		/* for the signal names */
 
 #include <glib.h>


### PR DESCRIPTION
If `_POSIX_SOURCE` is not defined, build on musl libc will fail with `error: ‘SIG_BLOCK’ undeclared`