### PR TITLE
Fix musl build again

### DIFF
--- a/src/subprocs.c
+++ b/src/subprocs.c
@@ -36,6 +36,9 @@
 # define fork  vfork
 #endif /* VMS */
 
+#ifndef _POSIX_SOURCE
+# define _POSIX_SOURCE
+#endif
 #include <signal.h>		/* for the signal names */
 
 #include <glib.h>


### PR DESCRIPTION
Resolves #14

Doesn't introduce a warning for redefinition of _POSIX_SOURCE.