### PR TITLE
Add CODEOWNERS and ignore tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 
 nohup.out
 justfile
+budgie-screensaver-*.tar*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global rule, if anything matches after this then that rule takes precedent
+* @serebit @BuddiesOfBudgie/best-buds


### PR DESCRIPTION
CODEOWNERS is **NOT** intended to be used to enforce or mandate blocking individuals for merge. Listings can / **SHOULD** be modified based on interest / desire for code reviews, and **SHOULD NOT** be considered exhaustive.